### PR TITLE
feat: Add LLVM IR (.ll) file support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,7 @@ dependencies = [
  "log",
  "regex",
  "rustc-build-sysroot",
+ "tempfile",
  "thiserror 2.0.17",
  "tracing",
  "tracing-appender",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ compiletest_rs = { version = "0.11.0" }
 regex = { version = "1.11.1", default-features = false }
 rustc-build-sysroot = { workspace = true }
 which = { version = "8.0.0", default-features = false, features = ["real-sys", "regex"] }
-
+tempfile = "3.13"
 [lints]
 workspace = true
 

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -288,19 +288,14 @@ impl Linker {
         for path in self.options.inputs.clone() {
             let mut file = File::open(&path).map_err(|e| LinkerError::IoError(path.clone(), e))?;
 
-            // Check for .ll extension first (IR files are plain text, no magic number)
-            let in_type = if path.extension().and_then(OsStr::to_str) == Some("ll") {
-                InputType::Ir
-            } else {
-                // determine whether the input is bitcode, ELF with embedded bitcode, an archive file
-                // or an invalid file
-                file.read_exact(&mut buf)
-                    .map_err(|e| LinkerError::IoError(path.clone(), e))?;
-                file.rewind()
-                    .map_err(|e| LinkerError::IoError(path.clone(), e))?;
-                detect_input_type(&buf)
-                    .ok_or_else(|| LinkerError::InvalidInputType(path.clone()))?
-            };
+            // determine whether the input is bitcode, ELF with embedded bitcode, an archive file
+            // or an invalid file
+            file.read_exact(&mut buf)
+                .map_err(|e| LinkerError::IoError(path.clone(), e))?;
+            file.rewind()
+                .map_err(|e| LinkerError::IoError(path.clone(), e))?;
+            let in_type = detect_input_type(&buf)
+                .ok_or_else(|| LinkerError::InvalidInputType(path.clone()))?;
 
             match in_type {
                 InputType::Archive => {
@@ -667,9 +662,29 @@ fn detect_input_type(data: &[u8]) -> Option<InputType> {
         _ => {
             if &data[..8] == b"!<arch>\x0A" {
                 Some(InputType::Archive)
+            } else if is_llvm_ir_header(&data) {
+                Some(InputType::Ir)
             } else {
                 None
             }
         }
     }
+}
+
+fn is_llvm_ir_header(data: &[u8]) -> bool {
+
+    // LLVM IR typically starts with so checking for this characters is a good enough heuristic:
+    // - ';' (e.g "; ModuleID = 'foo')
+    // - 'target ...' (e.g "target triple" or "target datalayout")
+    // - 'source_filename' (e.g "source_filename = "foo.ll")
+
+    let trimmed = match data.iter().position(|&b| !b.is_ascii_whitespace()) {
+        Some(position) => &data[position..],
+        None => return false,
+    };
+
+    trimmed.starts_with(b";")
+    || trimmed.starts_with(b"target ")
+    || trimmed.starts_with(b"source_filename")
+
 }

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -156,6 +156,8 @@ enum InputType {
     MachO,
     /// Archive file. (.a)
     Archive,
+    /// IR file. (.ll)
+    Ir,
 }
 
 impl std::fmt::Display for InputType {
@@ -168,6 +170,7 @@ impl std::fmt::Display for InputType {
                 Self::Elf => "elf",
                 Self::MachO => "Mach-O",
                 Self::Archive => "archive",
+                Self::Ir => "ir",
             }
         )
     }
@@ -285,14 +288,19 @@ impl Linker {
         for path in self.options.inputs.clone() {
             let mut file = File::open(&path).map_err(|e| LinkerError::IoError(path.clone(), e))?;
 
-            // determine whether the input is bitcode, ELF with embedded bitcode, an archive file
-            // or an invalid file
-            file.read_exact(&mut buf)
-                .map_err(|e| LinkerError::IoError(path.clone(), e))?;
-            file.rewind()
-                .map_err(|e| LinkerError::IoError(path.clone(), e))?;
-            let in_type = detect_input_type(&buf)
-                .ok_or_else(|| LinkerError::InvalidInputType(path.clone()))?;
+            // Check for .ll extension first (IR files are plain text, no magic number)
+            let in_type = if path.extension().and_then(OsStr::to_str) == Some("ll") {
+                InputType::Ir
+            } else {
+                // determine whether the input is bitcode, ELF with embedded bitcode, an archive file
+                // or an invalid file
+                file.read_exact(&mut buf)
+                    .map_err(|e| LinkerError::IoError(path.clone(), e))?;
+                file.rewind()
+                    .map_err(|e| LinkerError::IoError(path.clone(), e))?;
+                detect_input_type(&buf)
+                    .ok_or_else(|| LinkerError::InvalidInputType(path.clone()))?
+            };
 
             match in_type {
                 InputType::Archive => {
@@ -354,13 +362,27 @@ impl Linker {
             .or_else(|| detect_input_type(&data))
             .ok_or_else(|| LinkerError::InvalidInputType(path.to_owned()))?;
 
-        let bitcode = match in_type {
-            InputType::Bitcode => data,
-            InputType::Elf => match llvm::find_embedded_bitcode(self.context, &data) {
-                Ok(Some(bitcode)) => bitcode,
-                Ok(None) => return Err(LinkerError::MissingBitcodeSection(path.to_owned())),
-                Err(e) => return Err(LinkerError::EmbeddedBitcodeError(e)),
-            },
+        match in_type {
+            InputType::Bitcode => {
+                if !llvm::link_bitcode_buffer(self.context, self.module, &data) {
+                    return Err(LinkerError::LinkModuleError(path.to_owned()));
+                }
+            }
+            InputType::Ir => {
+                if !llvm::link_ir_buffer(self.context, self.module, &data) {
+                    return Err(LinkerError::LinkModuleError(path.to_owned()));
+                }
+            }
+            InputType::Elf => {
+                let bitcode = match llvm::find_embedded_bitcode(self.context, &data) {
+                    Ok(Some(bitcode)) => bitcode,
+                    Ok(None) => return Err(LinkerError::MissingBitcodeSection(path.to_owned())),
+                    Err(e) => return Err(LinkerError::EmbeddedBitcodeError(e)),
+                };
+                if !llvm::link_bitcode_buffer(self.context, self.module, &bitcode) {
+                    return Err(LinkerError::LinkModuleError(path.to_owned()));
+                }
+            }
             // we need to handle this here since archive files could contain
             // mach-o files, eg somecrate.rlib containing lib.rmeta which is
             // mach-o on macos
@@ -368,10 +390,6 @@ impl Linker {
             // this can't really happen
             InputType::Archive => panic!("nested archives not supported duh"),
         };
-
-        if !llvm::link_bitcode_buffer(self.context, self.module, &bitcode) {
-            return Err(LinkerError::LinkModuleError(path.to_owned()));
-        }
 
         Ok(())
     }

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -160,7 +160,7 @@ pub(crate) fn link_ir_buffer(
             buffer.as_ptr().cast(),
             buffer.len(),
             buffer_name.as_ptr(),
-            1,
+            0,
         )
     };
 

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -16,7 +16,7 @@ use llvm_sys::{
     bit_reader::LLVMParseBitcodeInContext2,
     core::{
         LLVMCountBasicBlocks, LLVMCreateMemoryBufferWithMemoryRange, LLVMDisposeMemoryBuffer,
-        LLVMDisposeMessage, LLVMGetDiagInfoDescription, LLVMGetDiagInfoSeverity,
+        LLVMDisposeMessage, LLVMDisposeModule, LLVMGetDiagInfoDescription, LLVMGetDiagInfoSeverity,
         LLVMGetEnumAttributeKindForName, LLVMGetMDString, LLVMGetModuleInlineAsm, LLVMGetTarget,
         LLVMGetValueName2, LLVMIsAFunction, LLVMModuleCreateWithNameInContext,
         LLVMPrintModuleToFile, LLVMRemoveEnumAttributeAtIndex, LLVMSetLinkage,
@@ -26,6 +26,7 @@ use llvm_sys::{
     error::{
         LLVMDisposeErrorMessage, LLVMGetErrorMessage, LLVMGetErrorTypeId, LLVMGetStringErrorTypeId,
     },
+    ir_reader::LLVMParseIRInContext,
     linker::LLVMLinkModules2,
     object::{
         LLVMCreateBinary, LLVMDisposeBinary, LLVMDisposeSectionIterator, LLVMGetSectionContents,
@@ -139,6 +140,50 @@ pub(crate) fn link_bitcode_buffer(
 
     if unsafe { LLVMParseBitcodeInContext2(context, buffer, &mut temp_module) } == 0 {
         linked = unsafe { LLVMLinkModules2(module, temp_module) } == 0;
+    }
+
+    unsafe { LLVMDisposeMemoryBuffer(buffer) };
+
+    linked
+}
+
+#[must_use]
+pub(crate) fn link_ir_buffer(
+    context: LLVMContextRef,
+    module: LLVMModuleRef,
+    buffer: &[u8],
+) -> bool {
+    let mut linked = false;
+    let buffer_name = c"ir_buffer";
+    let buffer = unsafe {
+        LLVMCreateMemoryBufferWithMemoryRange(
+            buffer.as_ptr().cast(),
+            buffer.len(),
+            buffer_name.as_ptr(),
+            1, // IR, so null-terminated
+        )
+    };
+
+    let mut temp_module = ptr::null_mut();
+    let mut error_msg = ptr::null_mut();
+
+    if unsafe { LLVMParseIRInContext(context, buffer, &mut temp_module, &mut error_msg) } == 0 {
+        if temp_module.is_null() {
+            error!("IR parsing succeeded but module is null");
+        } else {
+            linked = unsafe { LLVMLinkModules2(module, temp_module) } == 0;
+        }
+    } else {
+        if !error_msg.is_null() {
+            let err_str = unsafe { CStr::from_ptr(error_msg) };
+            error!("failed to parse IR: {:?}", err_str);
+            unsafe { LLVMDisposeMessage(error_msg) };
+        } else {
+            error!("failed to parse IR: unknown error");
+        }
+        if !temp_module.is_null() {
+            unsafe { LLVMDisposeModule(temp_module) };
+        }
     }
 
     unsafe { LLVMDisposeMemoryBuffer(buffer) };

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -155,38 +155,28 @@ pub(crate) fn link_ir_buffer(
 ) -> bool {
     let mut linked = false;
     let buffer_name = c"ir_buffer";
-    let buffer = unsafe {
+    let mem_buffer = unsafe {
         LLVMCreateMemoryBufferWithMemoryRange(
             buffer.as_ptr().cast(),
             buffer.len(),
             buffer_name.as_ptr(),
-            1, // IR, so null-terminated
+            1,
         )
     };
 
     let mut temp_module = ptr::null_mut();
     let mut error_msg = ptr::null_mut();
 
-    if unsafe { LLVMParseIRInContext(context, buffer, &mut temp_module, &mut error_msg) } == 0 {
-        if temp_module.is_null() {
-            error!("IR parsing succeeded but module is null");
-        } else {
-            linked = unsafe { LLVMLinkModules2(module, temp_module) } == 0;
-        }
+    if unsafe { LLVMParseIRInContext(context, mem_buffer, &mut temp_module, &mut error_msg) } == 0 {
+        linked = unsafe { LLVMLinkModules2(module, temp_module) } == 0;
     } else {
         if !error_msg.is_null() {
-            let err_str = unsafe { CStr::from_ptr(error_msg) };
-            error!("failed to parse IR: {:?}", err_str);
             unsafe { LLVMDisposeMessage(error_msg) };
-        } else {
-            error!("failed to parse IR: unknown error");
         }
         if !temp_module.is_null() {
             unsafe { LLVMDisposeModule(temp_module) };
         }
     }
-
-    unsafe { LLVMDisposeMemoryBuffer(buffer) };
 
     linked
 }

--- a/tests/ir_file_test.rs
+++ b/tests/ir_file_test.rs
@@ -1,0 +1,166 @@
+#![expect(unused_crate_dependencies, reason = "used in lib/bin")]
+
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+fn linker_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_bpf-linker"))
+}
+
+fn create_test_ir_file(dir: &Path, name: &str) -> PathBuf {
+    let ir_path = dir.join(format!("{}.ll", name));
+    let ir_content = format!(
+        r#"; ModuleID = '{name}'
+source_filename = "{name}"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf"
+
+define i32 @test_{name}(i32 %x) #0 {{
+entry:
+  %result = add i32 %x, 1
+  ret i32 %result
+}}
+
+attributes #0 = {{ noinline nounwind optnone }}
+
+!llvm.module.flags = !{{!0}}
+!0 = !{{i32 1, !"wchar_size", i32 4}}
+"#
+    );
+    fs::write(&ir_path, ir_content).expect("Failed to write test IR file");
+    ir_path
+}
+
+#[test]
+fn test_link_ir_file() {
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let ir_file = create_test_ir_file(temp_dir.path(), "alessandro");
+    let output_file = temp_dir.path().join("output.o");
+
+    let output = Command::new(linker_path())
+        .arg("--export")
+        .arg(format!("test_{}", "alessandro"))
+        .arg(&ir_file)
+        .arg("-o")
+        .arg(&output_file)
+        .output()
+        .expect("Failed to execute bpf-linker");
+
+    if !output.status.success() {
+        eprintln!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+        eprintln!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+        panic!("bpf-linker failed with status: {}", output.status);
+    }
+
+    assert!(
+        output_file.exists(),
+        "Output file should exist: {:?}",
+        output_file
+    );
+    assert!(
+        output_file.metadata().unwrap().len() > 0,
+        "Output file should not be empty"
+    );
+}
+
+#[test]
+fn test_link_multiple_ir_files() {
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let ir_file1 = create_test_ir_file(temp_dir.path(), "decina");
+    let ir_file2 = create_test_ir_file(temp_dir.path(), "despacito");
+    let output_file = temp_dir.path().join("output.o");
+
+    let output = Command::new(linker_path())
+        .arg("--export")
+        .arg("test_decina")
+        .arg("--export")
+        .arg("test_despacito")
+        .arg(&ir_file1)
+        .arg(&ir_file2)
+        .arg("-o")
+        .arg(&output_file)
+        .output()
+        .expect("Failed to execute bpf-linker");
+
+    if !output.status.success() {
+        eprintln!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+        eprintln!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+        panic!(
+            "bpf-linker failed with status: {} when linking multiple IR files",
+            output.status
+        );
+    }
+
+    assert!(output_file.exists(), "Output file should exist");
+}
+
+#[test]
+fn test_link_mixed_ir_and_bitcode() {
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let ir_file = create_test_ir_file(temp_dir.path(), "toly");
+    let bc_file = temp_dir.path().join("bc_part.bc");
+    let output_file = temp_dir.path().join("output.o");
+
+    // Create bitcode from IR using llvm-as
+    let llvm_as_output = Command::new("llvm-as")
+        .arg(&ir_file)
+        .arg("-o")
+        .arg(&bc_file)
+        .output();
+
+    if llvm_as_output.is_err() || !llvm_as_output.as_ref().unwrap().status.success() {
+        eprintln!("llvm-as not available or failed, skipping test");
+        return;
+    }
+
+    // Now create another IR file
+    let ir_file2 = create_test_ir_file(temp_dir.path(), "anatoly");
+
+    let output = Command::new(linker_path())
+        .arg("--export")
+        .arg("test_toly")
+        .arg("--export")
+        .arg("test_anatoly")
+        .arg(&bc_file)
+        .arg(&ir_file2)
+        .arg("-o")
+        .arg(&output_file)
+        .output()
+        .expect("Failed to execute bpf-linker");
+
+    if !output.status.success() {
+        eprintln!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+        eprintln!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+        panic!("bpf-linker failed when linking mixed IR and bitcode");
+    }
+
+    assert!(
+        output_file.exists(),
+        "Output file should exist after linking IR and bitcode"
+    );
+}
+
+#[test]
+fn test_invalid_ir_file() {
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let invalid_ir = temp_dir.path().join("invalid.ll");
+    fs::write(&invalid_ir, "This is not valid LLVM IR\n").expect("Failed to write invalid IR");
+
+    let output_file = temp_dir.path().join("output.o");
+
+    let output = Command::new(linker_path())
+        .arg(&invalid_ir)
+        .arg("-o")
+        .arg(&output_file)
+        .output()
+        .expect("Failed to execute bpf-linker");
+
+    // Should fail with invalid IR
+    assert!(
+        !output.status.success(),
+        "bpf-linker should fail with invalid IR"
+    );
+}


### PR DESCRIPTION
- Add ability to link LLVM IR text files directly by detecting .ll extension and parsing with LLVMParseIRInContext. Includes tests for single, multiple, and mixed IR/bitcode inputs.